### PR TITLE
Send strings over the websocket.

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,6 +1,7 @@
 import { WebSocketServer, createWebSocketStream } from 'ws';
 import * as net from 'net';
 
+
 // We Allow configuration through environmental variables.
 // If a MPD_UNIX_SOCKET is set it will override the host and port combination.
 const MPD_HOST = process.env.MPD_HOST ?? 'localhost';
@@ -11,12 +12,13 @@ const MPD_UNIX_SOCKET = process.env.MPD_UNIX_SOCKET;
 const wss = new WebSocketServer({ port: 8080 });
 
 wss.on('connection', (ws) => {
-  const webSocket = createWebSocketStream(ws, { encoding: 'utf8' });
+  const webSocket = createWebSocketStream(ws, {decodeStrings: false});
 
   webSocket.on('error', console.error);
   const mpdSocket = MPD_UNIX_SOCKET ? 
     net.connect(MPD_UNIX_SOCKET) :  
     net.connect(MPD_PORT, MPD_HOST);
+  mpdSocket.setEncoding('utf-8')
 
   webSocket.pipe(mpdSocket);
   mpdSocket.pipe(webSocket);


### PR DESCRIPTION
We need to set the encoding on the tcp read stream so that the bytes are read as strings and we need to not decode them to bytes on the websocket stream so that they are sent as strings in the websocket protocol.